### PR TITLE
fix offset to make similar in appearance to other content types

### DIFF
--- a/app/views/contents/remote_video/_form_middle.html.erb
+++ b/app/views/contents/remote_video/_form_middle.html.erb
@@ -1,5 +1,5 @@
 <fieldset>
-  <legend><span><%=t(:provide_details)%></span></legend>
+  <legend><span><%=t('contents.provide_details')%></span></legend>
   <div class="clearfix">
     <%= form.label :name %>
     <div class="input">
@@ -11,7 +11,7 @@
 </fieldset>
 
 <fieldset>
-  <legend><span><%=t(:select_feed)%></span></legend>
+  <legend><span><%=t('contents.select_feed')%></span></legend>
   <div class="clearfix">
     <% if @content.new_record? %>
       <%= render :partial => 'contents/form_elements/feeds' %>


### PR DESCRIPTION
Just changed the class and remove a blank label, so it appears more like other concerto types.  DID NOT TEST.  Can you tell me how to have concerto use my local version of a plugin?
