### PR TITLE
change to import element

### DIFF
--- a/app/assets/html/concerto_remote_video/concerto-remote-video.html
+++ b/app/assets/html/concerto_remote_video/concerto-remote-video.html
@@ -1,0 +1,45 @@
+<!--
+The `concerto-remote-video` element provides embedded video
+-->
+<dom-module id="concerto-remote-video">
+  <style>
+    :host {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    #video {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+
+  <template>
+    <iframe id="video" frameBorder="0"></iframe>
+  </template>
+
+  <script>
+    ConcertoRemoteVideo = Polymer({
+      is: "concerto-remote-video",
+
+      behaviors: [ConcertoBehaviors.BaseContent],
+
+      properties: {
+        baseUrl: String,
+        path: {
+          type: String,
+          observer: 'pathChanged'
+        },
+        config: Object
+      },
+
+      pathChanged: function() {
+        this.$.video.src = this.path;
+      }
+    });
+  </script>
+</dom-module>
+<script>
+  ConcertoBehaviors.ContentFactory.registerContent("concerto-remote-video", "ConcertoRemoteVideo");
+</script>

--- a/app/views/frontend/_concerto_remote_video.html
+++ b/app/views/frontend/_concerto_remote_video.html
@@ -1,45 +1,5 @@
-<!--
-The `concerto-remote-video` element provides embedded video
--->
-<dom-module id="concerto-remote-video">
-  <style>
-    :host {
-      display: block;
-      width: 100%;
-      height: 100%;
-    }
-
-    #video {
-      width: 100%;
-      height: 100%;
-    }
-  </style>
-
-  <template>
-    <iframe id="video" frameBorder="0"></iframe>
-  </template>
-
-  <script>
-    ConcertoRemoteVideo = Polymer({
-      is: "concerto-remote-video",
-
-      behaviors: [ConcertoBehaviors.BaseContent],
-
-      properties: {
-        baseUrl: String,
-        path: {
-          type: String,
-          observer: 'pathChanged'
-        },
-        config: Object
-      },
-
-      pathChanged: function() {
-        this.$.video.src = this.path;
-      }
-    });
-  </script>
-</dom-module>
-<script>
-  ConcertoBehaviors.ContentFactory.registerContent("concerto-remote-video", "ConcertoRemoteVideo");
-</script>
+<% content_for :head do %>
+<!-- from concerto-remote-video -->
+  <%= tag "link", rel: "import", href: asset_path("concerto_remote_video/concerto-remote-video.html") %>
+<!-- end from concerto-remote-video -->
+<% end %>


### PR DESCRIPTION
This is related to concerto/concerto-frontend#47 and should not be merged until that issue is closed.

I changed the polymer element from being included directly into the frontend screen to be imported because the ConcertoBehaviors were not being defined before this element was being initialized. By moving it to an import, it is now processed after the behaviors are loaded/initialized.

This wont work without the related branches in concerto and concerto-frontend repos. I also had to make a similar change the to concerto-iframe repo.