### PR TITLE
Fix for auto scaling videos to the container size using the container…

### DIFF
--- a/app/assets/html/concerto_remote_video/concerto-remote-video.html
+++ b/app/assets/html/concerto_remote_video/concerto-remote-video.html
@@ -42,6 +42,10 @@ The `concerto-remote-video` element provides embedded video
           video.id = 'video';
           video.src = this.path;
           video.autoplay = true;
+          video.style.marginLeft = "auto";
+          video.style.marginRight = "auto";
+          video.style.display = "block";
+          video.style.height = "100%";
           this.appendChild(video);
         } else {
           this.$.video.src = this.path;


### PR DESCRIPTION
I was having problems with the video tags auto scaling, this seems to fix it. Thoughts? This is specifically in Chrome, but since we use chromium displays that is important to me. 