### PR TITLE
Fixed videos being being cut off

### DIFF
--- a/app/assets/html/concerto_remote_video/concerto-remote-video.html
+++ b/app/assets/html/concerto_remote_video/concerto-remote-video.html
@@ -46,6 +46,7 @@ The `concerto-remote-video` element provides embedded video
           video.style.marginRight = "auto";
           video.style.display = "block";
           video.style.height = "100%";
+          video.style.width = "100%";
           this.appendChild(video);
         } else {
           this.$.video.src = this.path;


### PR DESCRIPTION
Without the width entered, videos will cut off the right or bottom of the screen if video ratio differs from the screen.